### PR TITLE
Add PDF support to RAG pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ embedding generation and chat use the `deepseek-r1:8b` model served by Ollama.
 ## Usage
 
 1. Place your documentation in a file named `documentacao.txt` in the project
-   root. The file should contain plain text. A small sample is provided in this
-   repository to demonstrate how the RAG pipeline works:
+   root (or point the script at another file with `--document`). The file can be
+   plain text or a PDF. A small sample is provided in this repository to
+   demonstrate how the RAG pipeline works:
 
    ```
    Como cadastrar um cliente na plataforma:
@@ -62,6 +63,6 @@ pip install -r requirements.txt
 echo "Meu texto" > documentacao.txt
 python main.py
 
-# custom document and question
-python main.py --document docs.txt --question "Qual \u00e9 o hor\u00e1rio de suporte?"
+# custom document and question (PDF or text)
+python main.py --document docs.pdf --question "Qual \u00e9 o hor\u00e1rio de suporte?"
 ```

--- a/main.py
+++ b/main.py
@@ -1,12 +1,21 @@
 from pathlib import Path
 import argparse
 
-from langchain_community.document_loaders import TextLoader
+from langchain_community.document_loaders import TextLoader, PyPDFLoader
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.vectorstores import Chroma
 from langchain_community.embeddings import OllamaEmbeddings
 from langchain_community.chat_models import ChatOllama
 from langchain.chains import RetrievalQA
+
+
+def load_document(path: Path):
+    """Load a document from a text or PDF file."""
+    if path.suffix.lower() == ".pdf":
+        loader = PyPDFLoader(str(path))
+    else:
+        loader = TextLoader(str(path), encoding="utf-8")
+    return loader.load()
 
 
 def main() -> None:
@@ -32,9 +41,8 @@ def main() -> None:
             f"Arquivo '{doc_path}' n\u00e3o encontrado. Certifique-se de que o arquivo est\u00e1 no caminho especificado."
         )
 
-    # 1. Carregar documentos (pode ser .txt, .md, etc.)
-    loader = TextLoader(str(doc_path), encoding="utf-8")
-    docs = loader.load()
+    # 1. Carregar documentos de texto ou PDF
+    docs = load_document(doc_path)
 
     # 2. Dividir em pedaços pequenos
     splitter = CharacterTextSplitter(chunk_size=500, chunk_overlap=50)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ langchain-community
 ollama
 chromadb
 tqdm
+pdfminer.six


### PR DESCRIPTION
## Summary
- allow `main.py` to load PDF or text files via `PyPDFLoader`
- mention PDF support in README with example usage
- add `pdfminer.six` dependency

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_686d43c29b8c833285e23fc2ec2f70f1