### PR TITLE
Update to langchain-ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ using [Ollama](https://github.com/ollama/ollama) with LangChain. The `main.py`
 script loads text documents, creates embeddings with Ollama, indexes them in a
 local Chroma database, and answers questions using a chat model. Both the
 embedding generation and chat use the `deepseek-r1:8b` model served by Ollama.
+Ollama-specific integrations are provided by the `langchain-ollama` package.
+The retrieval chain in `main.py` is queried using the `invoke()` method.
 
 ## Installation
 
@@ -23,6 +25,9 @@ embedding generation and chat use the `deepseek-r1:8b` model served by Ollama.
    ```bash
    pip install -r requirements.txt
    ```
+
+   The requirements include `langchain-ollama` which provides the
+   `OllamaEmbeddings` and `ChatOllama` classes used in `main.py`.
 
 ## Usage
 

--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ import argparse
 from langchain_community.document_loaders import TextLoader, PyPDFLoader
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.vectorstores import Chroma
-from langchain_community.embeddings import OllamaEmbeddings
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama.embeddings import OllamaEmbeddings
+from langchain_ollama.chat_models import ChatOllama
 from langchain.chains import RetrievalQA
 
 
@@ -65,7 +65,7 @@ def main() -> None:
 
     # 7. Teste prático
     pergunta = args.question
-    resposta = qa_chain.run(pergunta)
+    resposta = qa_chain.invoke({"query": pergunta})["result"]
 
     print("\n🧠 Pergunta:", pergunta)
     print("💬 Resposta do modelo:")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 langchain
 langchain-community
 ollama
+langchain-ollama
 chromadb
 tqdm
 pdfminer.six


### PR DESCRIPTION
## Summary
- update imports to use `langchain-ollama`
- call `invoke()` instead of `run()`
- document the new dependency and API change in README
- add `langchain-ollama` requirement

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686d5031f6b48332803be76365c49248