### PR TITLE
Add Flask web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,16 @@ python main.py
 # custom document and question (PDF or text)
 python main.py --document docs.pdf --question "Qual \u00e9 o hor\u00e1rio de suporte?"
 ```
+
+## Web Server
+
+A small Flask application is included to query the RAG pipeline through a web
+interface. After installing the requirements and starting Ollama, run:
+
+```bash
+python server.py
+```
+
+The server will start on [http://localhost:8000](http://localhost:8000). Open
+this URL in a browser and submit questions using the page. Answers returned by
+the retrieval chain will be displayed below the form.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ langchain-ollama
 chromadb
 tqdm
 pdfminer.six
+Flask

--- a/server.py
+++ b/server.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+from flask import Flask, request, jsonify, render_template
+from langchain_community.document_loaders import TextLoader, PyPDFLoader
+from langchain.text_splitter import CharacterTextSplitter
+from langchain_community.vectorstores import Chroma
+from langchain_ollama.embeddings import OllamaEmbeddings
+from langchain_ollama.chat_models import ChatOllama
+from langchain.chains import RetrievalQA
+
+app = Flask(__name__)
+
+
+def load_document(path: Path):
+    if path.suffix.lower() == ".pdf":
+        loader = PyPDFLoader(str(path))
+    else:
+        loader = TextLoader(str(path), encoding="utf-8")
+    return loader.load()
+
+
+def build_chain(doc_path: Path) -> RetrievalQA:
+    docs = load_document(doc_path)
+    splitter = CharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    chunks = splitter.split_documents(docs)
+    embeddings = OllamaEmbeddings(
+        model="deepseek-r1:8b", base_url="http://localhost:11434"
+    )
+    db = Chroma.from_documents(chunks, embeddings, persist_directory="./chroma_db")
+    db.persist()
+    llm = ChatOllama(model="deepseek-r1:8b", base_url="http://localhost:11434")
+    return RetrievalQA.from_chain_type(llm=llm, retriever=db.as_retriever())
+
+
+qa_chain = build_chain(Path("documentacao.txt"))
+
+
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/ask", methods=["POST"])
+def ask():
+    data = request.get_json(force=True)
+    question = data.get("question", "")
+    answer = qa_chain.invoke({"query": question})["result"]
+    return jsonify({"answer": answer})
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,10 @@
+document.getElementById('ask').addEventListener('click', async () => {
+    const question = document.getElementById('question').value;
+    const res = await fetch('/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ question })
+    });
+    const data = await res.json();
+    document.getElementById('answer').textContent = data.answer;
+});

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,5 @@
+body { font-family: Arial, sans-serif; margin: 2rem; }
+#form { margin-bottom: 1rem; }
+#question { width: 70%; padding: 0.5rem; }
+#ask { padding: 0.5rem 1rem; }
+pre { background: #f0f0f0; padding: 1rem; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Ollama Q&A</title>
+    <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+    <h1>Ask a question</h1>
+    <div id="form">
+        <input id="question" type="text" placeholder="Type your question">
+        <button id="ask">Ask</button>
+    </div>
+    <pre id="answer"></pre>
+    <script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a small Flask server with `/ask` endpoint
- build simple HTML/CSS/JS frontend
- document how to start the server
- include Flask in requirements

## Testing
- `python -m py_compile main.py server.py`

------
https://chatgpt.com/codex/tasks/task_e_686d518e2ac8833288a7fa86f18c4c00