### PR TITLE
Update langchain-ollama and remove deprecated persistence

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,7 +55,6 @@ def main() -> None:
 
     # 4. Indexar os documentos em Chroma
     db = Chroma.from_documents(chunks, embeddings, persist_directory="./chroma_db")
-    db.persist()  # salva localmente
 
     # 5. Configurar o modelo via Ollama
     llm = ChatOllama(model="deepseek-r1:8b", base_url="http://localhost:11434")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 langchain==0.1.7
 langchain-community==0.0.24
 ollama==0.1.7
-langchain-ollama==0.0.6
+langchain-ollama==0.3.3
 chromadb==0.4.24
 tqdm==4.66.1
 pdfminer.six==20221105

--- a/server.py
+++ b/server.py
@@ -26,7 +26,6 @@ def build_chain(doc_path: Path) -> RetrievalQA:
         model="deepseek-r1:8b", base_url="http://localhost:11434"
     )
     db = Chroma.from_documents(chunks, embeddings, persist_directory="./chroma_db")
-    db.persist()
     llm = ChatOllama(model="deepseek-r1:8b", base_url="http://localhost:11434")
     return RetrievalQA.from_chain_type(llm=llm, retriever=db.as_retriever())
 


### PR DESCRIPTION
## Summary
- update langchain-ollama requirement to a published version
- drop deprecated `db.persist()` usage in scripts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_community')*

------
https://chatgpt.com/codex/tasks/task_e_686d41e45ab48332ad4013bd33c548ef