### PR TITLE
Relax langchain version constraints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-langchain==0.1.7
-langchain-community==0.0.24
+langchain>=0.1.7
+langchain-community>=0.0.24
 ollama==0.1.7
 langchain-ollama==0.3.3
 chromadb==0.4.24


### PR DESCRIPTION
## Summary
- loosen version requirements for `langchain` and `langchain-community`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_community')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_686d5bf3e9a48332957f1f8921309387