### PR TITLE
Disable Chroma telemetry

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,9 @@ import argparse
 from langchain_community.document_loaders import TextLoader, PyPDFLoader
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.vectorstores import Chroma
+from chromadb.config import Settings
+
+CHROMA_SETTINGS = Settings(anonymized_telemetry=False)
 from langchain_ollama.embeddings import OllamaEmbeddings
 from langchain_ollama.chat_models import ChatOllama
 from langchain.chains import RetrievalQA
@@ -54,7 +57,12 @@ def main() -> None:
     )
 
     # 4. Indexar os documentos em Chroma
-    db = Chroma.from_documents(chunks, embeddings, persist_directory="./chroma_db")
+    db = Chroma.from_documents(
+        chunks,
+        embeddings,
+        persist_directory="./chroma_db",
+        client_settings=CHROMA_SETTINGS,
+    )
 
     # 5. Configurar o modelo via Ollama
     llm = ChatOllama(model="deepseek-r1:8b", base_url="http://localhost:11434")

--- a/server.py
+++ b/server.py
@@ -3,6 +3,9 @@ from flask import Flask, request, jsonify, render_template
 from langchain_community.document_loaders import TextLoader, PyPDFLoader
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.vectorstores import Chroma
+from chromadb.config import Settings
+
+CHROMA_SETTINGS = Settings(anonymized_telemetry=False)
 from langchain_ollama.embeddings import OllamaEmbeddings
 from langchain_ollama.chat_models import ChatOllama
 from langchain.chains import RetrievalQA
@@ -25,7 +28,12 @@ def build_chain(doc_path: Path) -> RetrievalQA:
     embeddings = OllamaEmbeddings(
         model="deepseek-r1:8b", base_url="http://localhost:11434"
     )
-    db = Chroma.from_documents(chunks, embeddings, persist_directory="./chroma_db")
+    db = Chroma.from_documents(
+        chunks,
+        embeddings,
+        persist_directory="./chroma_db",
+        client_settings=CHROMA_SETTINGS,
+    )
     llm = ChatOllama(model="deepseek-r1:8b", base_url="http://localhost:11434")
     return RetrievalQA.from_chain_type(llm=llm, retriever=db.as_retriever())
 


### PR DESCRIPTION
## Summary
- disable telemetry from Chroma to avoid PostHog warnings in both main and server applications

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langchain_community')*

------
https://chatgpt.com/codex/tasks/task_e_686d74ee82b88332a495bb9ee096d5a1