### PR TITLE
Pin numpy to <2

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ but are not guaranteed. Using a virtual environment is highly recommended.
    pip install -r requirements.txt
    ```
 
+   The dependencies are pinned to versions known to work together.
+   In particular, `numpy` is restricted to versions below 2.0 because
+   `chromadb` does not yet support the breaking changes in NumPy 2.
+
    The requirements include `langchain-ollama` which provides the
    `OllamaEmbeddings` and `ChatOllama` classes used in `main.py`.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 langchain-ollama==0.3.3
 ollama==0.4.9
 chromadb==0.4.24
+numpy<2
 tqdm==4.66.1
 pdfminer.six==20221105
 Flask==2.3.2


### PR DESCRIPTION
## Summary
- fix installation instructions for Chromadb by pinning numpy below 2
- document the version pin in README

## Testing
- `pytest -q` *(fails: No module named 'langchain_community')*

------
https://chatgpt.com/codex/tasks/task_e_686d7c4c104083329e89c75f7a973c81